### PR TITLE
Fix cargo not considered empty if it has a tiny value due to floating point imprecision

### DIFF
--- a/src/mable/transport_operation.py
+++ b/src/mable/transport_operation.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from mable.event_management import VesselEvent
     from mable.simulation_space.universe import Location
 
+EMPTY_CARGO_EPSILON = 1e-7
 
 @dataclass
 class CargoCapacity(JsonAble):
@@ -168,7 +169,7 @@ class CargoHold:
         i = 0
         while is_empty and i < len(all_cargo_types):
             one_cargo_types = all_cargo_types[i]
-            if self.get_current_load(one_cargo_types) > 0:
+            if self.get_current_load(one_cargo_types) > EMPTY_CARGO_EPSILON:
                 is_empty = False
             i += 1
         return is_empty


### PR DESCRIPTION
This bug causes certain types of schedules to fail to verify the cargo requirements. It occurs when the trades in the schedule are carried out in a non-sequential order (eg. [(PICK_UP, 'A'), (PICK_UP, 'B'), (DROP_OFF, 'A'), (DROP_OFF, 'B')]) i.e when a vessel is carrying cargo from more than one trade at a time.
This is due to the imprecision in floating point when adding and subtracting large numbers (the cargo amounts) out of sequence, which causes the Schedule::verify_schedule_cargo to fail due to CargoHold::is_empty returning False due to a comparison error highlighted below. The value returned by CargoHold::get_current_load may possibly be a tiny number (due to floating point imprecision) just above 0. It stems from the fact that a + b - a - b does not equal a - a + b - b when evaluated on floats from left to right.

The bug can be demonstrated as follows with the following snippet:
```py
from mable.transport_operation import CargoHold, CargoCapacity

cargo = CargoHold([CargoCapacity("Oil", 200, 9000000)])
cargo.load_cargo("Oil", 450460.1)
cargo.load_cargo("Oil", 344556.2)
cargo.unload_cargo("Oil", 450460.1)
cargo.unload_cargo("Oil", 344556.2)

print("Cargo load:", cargo.get_current_load("Oil"))
print("Is cargo hold empty?", cargo.is_empty())
```
In this snippet, since the same amount of cargo is unloaded after loading, the cargo hold should be empty but due to the bug, it incorrectly says that it is not. It can be fixed by replacing the 0 above with a small epsilon value, below which the cargo hold can be considered as empty.

Expected Output:
```
Cargo load: 5.820766091346741e-11
Is cargo hold empty? True
```

Current Output:
```
Cargo load: 5.820766091346741e-11
Is cargo hold empty? False
```

The ideal solution to this would be to do one of the following:
- Always use integers for cargo amounts
- Keep track of individual cargo quantities instead of summing them up